### PR TITLE
refactor: Update ExoPlayer to the 2.18.0 version

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -14,7 +14,6 @@
             <option value="$PROJECT_DIR$/app" />
           </set>
         </option>
-        <option name="resolveModulePerSourceSet" value="false" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,13 +4,13 @@ plugins {
 }
 
 android {
-    compileSdkVersion 30
-    buildToolsVersion "30.0.3"
+    compileSdkVersion 33
+    buildToolsVersion "33.0.0"
 
     defaultConfig {
         applicationId "com.mone.rtmp_exoplayer"
         minSdkVersion 16
-        targetSdkVersion 30
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
         multiDexEnabled true
@@ -40,21 +40,22 @@ android {
 
 dependencies {
 
-    implementation 'androidx.core:core-ktx:1.3.2'
-    implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation 'com.google.android.material:material:1.3.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
-    implementation 'androidx.lifecycle:lifecycle-livedata-ktx:2.3.0'
-    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.3.0'
+    implementation 'androidx.core:core-ktx:1.8.0'
+    implementation 'androidx.appcompat:appcompat:1.4.2'
+    implementation 'com.google.android.material:material:1.6.1'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+    implementation 'androidx.fragment:fragment-ktx:1.5.0'
+    implementation 'androidx.lifecycle:lifecycle-livedata-ktx:2.5.0'
+    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.0'
 
     //region ExoPlayer
-    def exoplayerVersion = '2.13.2'
+    def exoplayerVersion = '2.18.0'
     implementation("com.google.android.exoplayer:exoplayer-core:$exoplayerVersion")
     implementation("com.google.android.exoplayer:exoplayer-ui:$exoplayerVersion")
     implementation("com.google.android.exoplayer:extension-rtmp:$exoplayerVersion")
     //endregion
 
     testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,7 +9,9 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.RTMPExoPlayer">
-        <activity android:name=".MainActivity">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/com/mone/rtmp_exoplayer/ui/player/PlayerFragment.kt
+++ b/app/src/main/java/com/mone/rtmp_exoplayer/ui/player/PlayerFragment.kt
@@ -6,22 +6,22 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.ViewModelProvider
+import androidx.fragment.app.viewModels
+import com.google.android.exoplayer2.ExoPlayer
 import com.google.android.exoplayer2.MediaItem
-import com.google.android.exoplayer2.SimpleExoPlayer
-import com.google.android.exoplayer2.ext.rtmp.RtmpDataSourceFactory
+import com.google.android.exoplayer2.ext.rtmp.RtmpDataSource
 import com.google.android.exoplayer2.source.ProgressiveMediaSource
 import com.google.android.exoplayer2.trackselection.AdaptiveTrackSelection
 import com.google.android.exoplayer2.trackselection.DefaultTrackSelector
-import com.google.android.exoplayer2.ui.PlayerView
+import com.google.android.exoplayer2.ui.StyledPlayerView
 import com.google.android.exoplayer2.upstream.DefaultBandwidthMeter
 import com.mone.rtmp_exoplayer.databinding.FragmentPlayerBinding
 
 class PlayerFragment : Fragment() {
 
     private lateinit var binding: FragmentPlayerBinding
-    private lateinit var viewModel: PlayerViewModel
-    private lateinit var player: SimpleExoPlayer
+    private val viewModel by viewModels<PlayerViewModel>()
+    private lateinit var exoPlayer: ExoPlayer
     private val url = "rtmp://192.168.1.52/LiveApp/test"
     // audio: rtmp://202.123.27.133:1935/bestfm/livestream
 
@@ -33,17 +33,12 @@ class PlayerFragment : Fragment() {
         return binding.root
     }
 
-    override fun onActivityCreated(savedInstanceState: Bundle?) {
-        super.onActivityCreated(savedInstanceState)
-        viewModel = ViewModelProvider(this).get(PlayerViewModel::class.java)
-    }
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         initializePlayer()
         playVideo()
-        player.playWhenReady = true
-        player.prepare()
+        exoPlayer.playWhenReady = true
+        exoPlayer.prepare()
     }
 
     /**
@@ -59,25 +54,22 @@ class PlayerFragment : Fragment() {
         )
         trackSelector.setParameters(trackSelector.buildUponParameters().setMaxVideoSizeSd())
 
-        player = SimpleExoPlayer.Builder(requireContext())
+        exoPlayer = ExoPlayer.Builder(requireContext())
             .setTrackSelector(trackSelector)
             .setBandwidthMeter(DefaultBandwidthMeter.getSingletonInstance(requireContext()))
             .build()
 
-        binding.simplePlayer.player = player
-        binding.simplePlayer.setShowBuffering(PlayerView.SHOW_BUFFERING_ALWAYS)
-        binding.simplePlayer.setPlaybackPreparer {
-            player.prepare()
-        }
+        binding.styledPlayer.player = exoPlayer
+        binding.styledPlayer.setShowBuffering(StyledPlayerView.SHOW_BUFFERING_ALWAYS)
     }
 
     /**
      * Play RTMP
      */
     private fun playVideo() {
-        val videoSource = ProgressiveMediaSource.Factory(RtmpDataSourceFactory())
+        val videoSource = ProgressiveMediaSource.Factory(RtmpDataSource.Factory())
             .createMediaSource(MediaItem.fromUri(Uri.parse(url)))
-        player.setMediaSource(videoSource)
+        exoPlayer.setMediaSource(videoSource)
     }
 
 

--- a/app/src/main/res/layout/fragment_player.xml
+++ b/app/src/main/res/layout/fragment_player.xml
@@ -9,8 +9,8 @@
     android:keepScreenOn="true"
     tools:context=".ui.player.PlayerFragment">
 
-    <com.google.android.exoplayer2.ui.PlayerView
-        android:id="@+id/simple_player"
+    <com.google.android.exoplayer2.ui.StyledPlayerView
+        android:id="@+id/styled_player"
         android:layout_width="match_parent"
         android:layout_height="0dp"
         app:layout_constraintDimensionRatio="1.5:1"
@@ -26,7 +26,7 @@
         android:textColor="@color/white"
         android:textSize="18sp"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/simple_player" />
+        app:layout_constraintTop_toBottomOf="@+id/styled_player" />
 
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,8 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.0-alpha09'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.30"
+        classpath 'com.android.tools.build:gradle:7.4.0-alpha08'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.10"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Jan 21 14:34:32 IRST 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-rc-2-all.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
This PR Updates the deprecated usages of `ExoPlayer` and Updates to `2.18.0` based on the [official changes](https://github.com/google/ExoPlayer/blob/release-v2/RELEASENOTES.md)